### PR TITLE
Run Go 'master' instead of incorrect 'tip'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ language: go
 go:
  - "1.9"
  - "1.10"
- - "tip"
+ - "1.11"
+ - "master"
 
 script:
  - go test -race $(go list ./... | grep -v /vendor/)
 
 matrix:
   allow_failures:
-    - go: "tip"
+    - go: "master"


### PR DESCRIPTION
Looking at the error output on 'tip' it appears that `gimme` does not recognize it and thus falls back to 1.5.

Also see https://docs.travis-ci.com/user/languages/go/.