### PR TITLE
Update base URLs

### DIFF
--- a/client.go
+++ b/client.go
@@ -65,9 +65,9 @@ func NewClient(opts *Options) (*Client, error) {
 func (s *Client) URL() string {
 	switch s.Env {
 	case "production":
-		return "https://swicpc.bankgirot.se/swish-cpcapi/api/v1"
+		return "https://cpc.getswish.net/swish-cpcapi/api/v1"
 	default:
-		return "https://mss.swicpc.bankgirot.se/swish-cpcapi/api/v1"
+		return "https://mss.cpc.getswish.net/swish-cpcapi/api/v1"
 	}
 }
 

--- a/endpoints_test.go
+++ b/endpoints_test.go
@@ -28,7 +28,7 @@ func TestCreatePaymentRequest(t *testing.T) {
 			responder: func(req *http.Request) (*http.Response, error) {
 				resp := httpmock.NewStringResponse(200, "")
 
-				resp.Header.Set("Location", "https://mss.swicpc.bankgirot.se/swish-cpcapi/api/v1/paymentrequests/AB23D7406ECE4542A80152D909EF9F6B")
+				resp.Header.Set("Location", "https://mss.cpc.getswish.net/swish-cpcapi/api/v1/paymentrequests/AB23D7406ECE4542A80152D909EF9F6B")
 
 				return resp, nil
 			},
@@ -57,7 +57,7 @@ func TestCreatePaymentRequest(t *testing.T) {
 			responder: func(req *http.Request) (*http.Response, error) {
 				resp := httpmock.NewStringResponse(500, "")
 
-				resp.Header.Set("Location", "https://mss.swicpc.bankgirot.se/swish-cpcapi/api/v1/paymentrequests/AB23D7406ECE4542A80152D909EF9F6B")
+				resp.Header.Set("Location", "https://mss.cpc.getswish.net/swish-cpcapi/api/v1/paymentrequests/AB23D7406ECE4542A80152D909EF9F6B")
 
 				return resp, nil
 			},
@@ -76,7 +76,7 @@ func TestCreatePaymentRequest(t *testing.T) {
 	assert.Nil(t, err)
 
 	for _, test := range tests {
-		httpmock.RegisterResponder("POST", "https://mss.swicpc.bankgirot.se/swish-cpcapi/api/v1/paymentrequests", test.responder)
+		httpmock.RegisterResponder("POST", "https://mss.cpc.getswish.net/swish-cpcapi/api/v1/paymentrequests", test.responder)
 
 		res, err := client.CreatePaymentRequest(context.Background(), &PaymentRequest{
 			PayeePaymentReference: "0123456789",
@@ -162,7 +162,7 @@ func TestPaymentRequest(t *testing.T) {
 	assert.Nil(t, err)
 
 	for _, test := range tests {
-		httpmock.RegisterResponder("GET", "https://mss.swicpc.bankgirot.se/swish-cpcapi/api/v1/paymentrequests/AB23D7406ECE4542A80152D909EF9F6B", test.responder)
+		httpmock.RegisterResponder("GET", "https://mss.cpc.getswish.net/swish-cpcapi/api/v1/paymentrequests/AB23D7406ECE4542A80152D909EF9F6B", test.responder)
 
 		res, err := client.PaymentRequest(context.Background(), "AB23D7406ECE4542A80152D909EF9F6B")
 
@@ -189,7 +189,7 @@ func TestCreateRefundRequest(t *testing.T) {
 			responder: func(req *http.Request) (*http.Response, error) {
 				resp := httpmock.NewStringResponse(200, "")
 
-				resp.Header.Set("Location", "https://mss.swicpc.bankgirot.se/swish-cpcapi/api/v1/refunds/AB23D7406ECE4542A80152D909EF9F6B")
+				resp.Header.Set("Location", "https://mss.cpc.getswish.net/swish-cpcapi/api/v1/refunds/AB23D7406ECE4542A80152D909EF9F6B")
 
 				return resp, nil
 			},
@@ -227,7 +227,7 @@ func TestCreateRefundRequest(t *testing.T) {
 			responder: func(req *http.Request) (*http.Response, error) {
 				resp := httpmock.NewStringResponse(500, "")
 
-				resp.Header.Set("Location", "https://mss.swicpc.bankgirot.se/swish-cpcapi/api/v1/paymentrequests/AB23D7406ECE4542A80152D909EF9F6B")
+				resp.Header.Set("Location", "https://mss.cpc.getswish.net/swish-cpcapi/api/v1/paymentrequests/AB23D7406ECE4542A80152D909EF9F6B")
 
 				return resp, nil
 			},
@@ -246,7 +246,7 @@ func TestCreateRefundRequest(t *testing.T) {
 	assert.Nil(t, err)
 
 	for _, test := range tests {
-		httpmock.RegisterResponder("POST", "https://mss.swicpc.bankgirot.se/swish-cpcapi/api/v1/refunds", test.responder)
+		httpmock.RegisterResponder("POST", "https://mss.cpc.getswish.net/swish-cpcapi/api/v1/refunds", test.responder)
 
 		res, err := client.CreateRefundRequest(context.Background(), &PaymentRequest{
 			OriginalPaymentReference: "AB23D7406ECE4542A80152D909EF9F6B",
@@ -332,7 +332,7 @@ func TestRefundRequest(t *testing.T) {
 	assert.Nil(t, err)
 
 	for _, test := range tests {
-		httpmock.RegisterResponder("GET", "https://mss.swicpc.bankgirot.se/swish-cpcapi/api/v1/refunds/AB23D7406ECE4542A80152D909EF9F6B", test.responder)
+		httpmock.RegisterResponder("GET", "https://mss.cpc.getswish.net/swish-cpcapi/api/v1/refunds/AB23D7406ECE4542A80152D909EF9F6B", test.responder)
 
 		res, err := client.RefundRequest(context.Background(), "AB23D7406ECE4542A80152D909EF9F6B")
 


### PR DESCRIPTION
Looking at the docs on 2018-10-20 it seems that the current URLs are:

- `https://mss.cpc.getswish.net/swish-cpcapi/api/v1` (https://developer.getswish.se/merchants-test-con/4-create-payment-request/)
- `https://cpc.getswish.net/swish-cpcapi/api/v1` (https://developer.getswish.se/merchants-api-manual/7-production-environment/)